### PR TITLE
Magento2 185 send emails after order save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Sending of confirmation mail in case of a failed order import
+
 ## [2.9.9] - 2018-10-28
 ### Added
 - Configuration for Shopgate payment method title

--- a/src/Helper/Order.php
+++ b/src/Helper/Order.php
@@ -57,7 +57,7 @@ class Order
     /** @var OrderRepository */
     private $orderRepository;
     /** @var MageOrder */
-    private $mageOrder;
+    protected $mageOrder;
     /** @var OrderRepositoryInterface */
     private $sgOrderRepository;
     /** @var CoreInterface */
@@ -71,7 +71,7 @@ class Order
     /** @var Shipping */
     private $shippingHelper;
     /** @var ManagerInterface */
-    private $eventManager;
+    protected $eventManager;
 
     /**
      * @param Utility                  $utility

--- a/src/Helper/Order.php
+++ b/src/Helper/Order.php
@@ -148,6 +148,7 @@ class Order
      * @throws \Magento\Framework\Exception\InputException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \ShopgateLibraryException
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function setStartAdd()
     {
@@ -182,6 +183,7 @@ class Order
      *
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \ShopgateLibraryException
+     * @throws \Magento\Framework\Exception\InputException
      */
     protected function setStartUpdate()
     {
@@ -200,7 +202,7 @@ class Order
      */
     public function setEndUpdate()
     {
-        $this->mageOrder->addStatusHistoryComment(__('[SHOPGATE] Order updated by Shopgate.'), false)
+        $this->mageOrder->addStatusHistoryComment(__('[SHOPGATE] Order updated by Shopgate.'))
                         ->setIsCustomerNotified(false);
 
         $this->orderRepository->save($this->mageOrder);
@@ -220,6 +222,8 @@ class Order
 
     /**
      * Checks if shipments should be updated for an existing order
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
      */
     protected function setUpdateShipping()
     {
@@ -249,8 +253,7 @@ class Order
     protected function setOrderStatusHistory()
     {
         $this->mageOrder->addStatusHistoryComment(
-            __('[SHOPGATE] Order added by Shopgate # %1', $this->sgOrder->getOrderNumber()),
-            false
+            __('[SHOPGATE] Order added by Shopgate # %1', $this->sgOrder->getOrderNumber())
         )->setIsCustomerNotified(false);
     }
 
@@ -261,10 +264,10 @@ class Order
      */
     protected function setOrderPayment()
     {
-        if ($this->sgOrder->getIsPaid() && $this->mageOrder->getBaseTotalDue()) {
+        if ($this->sgOrder->getIsPaid() && $this->mageOrder->getBaseTotalDue() && $this->mageOrder->getPayment()) {
             $this->mageOrder->getPayment()->setShouldCloseParentTransaction(true);
             $this->mageOrder->getPayment()->registerCaptureNotification($this->sgOrder->getAmountComplete());
-            $this->mageOrder->addStatusHistoryComment(__('[SHOPGATE] Payment received.'), false)
+            $this->mageOrder->addStatusHistoryComment(__('[SHOPGATE] Payment received.'))
                             ->setIsCustomerNotified(false);
         }
     }
@@ -275,12 +278,13 @@ class Order
     protected function setOrderShipping()
     {
         $shippingTitle = $this->sgOrder->getShippingInfos()->getDisplayName();
-        //@todo-konstantin: double check that I don't need to: IF $this->sgOrder->getShippingType() === 'PLUGINAPI'
         $this->mageOrder->setShippingDescription($shippingTitle);
     }
 
     /**
      * Send order notification if activated in config
+     *
+     * @throws \Magento\Framework\Exception\MailException
      */
     protected function setOrderNotification()
     {

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -22,8 +22,8 @@
                 <item name="order_state" xsi:type="string">order_state</item>
                 <item name="order_shipping" xsi:type="string">order_shipping</item>
                 <item name="custom_fields" xsi:type="string">custom_fields</item>
-                <item name="order_notification" xsi:type="string">order_notification</item>
-                <item name="end_add" xsi:type="string">end_add</item><!-- must be last -->
+                <item name="end_add" xsi:type="string">end_add</item>
+                <item name="order_notification" xsi:type="string">order_notification</item><!-- must be last -->
             </argument>
             <argument name="updateOrderMethods" xsi:type="array">
                 <item name="start_update" xsi:type="string">start_update</item><!-- must be first -->


### PR DESCRIPTION
# Pull Request Template

## Description

Stop sending confirmation mails for orders, which were not sucessfully imported

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
