### PR TITLE
MAGENTO2-196 fix order status empty issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - Sending of confirmation mail in case of a failed order import
+- Status issues after unholding orders, which were imported with the status On Hold
 
 ## [2.9.9] - 2018-10-28
 ### Added

--- a/src/Helper/Order.php
+++ b/src/Helper/Order.php
@@ -246,7 +246,7 @@ class Order
         $orderState  = $this->utility->getStateForStatus($orderStatus);
         if ($orderState === MageOrder::STATE_HOLDED) {
             $this->mageOrder->hold();
-            
+
             return;
         }
         $this->mageOrder->setState($orderState)->setStatus($orderStatus);

--- a/src/Helper/Order.php
+++ b/src/Helper/Order.php
@@ -244,6 +244,11 @@ class Order
     {
         $orderStatus = $this->mageOrder->getPayment()->getMethodInstance()->getConfigData('order_status');
         $orderState  = $this->utility->getStateForStatus($orderStatus);
+        if ($orderState === MageOrder::STATE_HOLDED) {
+            $this->mageOrder->hold();
+            
+            return;
+        }
         $this->mageOrder->setState($orderState)->setStatus($orderStatus);
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

fix status issues after unholding orders, which were imported with the status On Hold

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
