### PR TITLE
MAGENTO2-712: applying coupons before shipping during addOrder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - Order import if poduct is only available once
+- Free shipping coupons durong addOrder
 
 ## [2.9.15] - 2020-02-05
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - Order import if poduct is only available once
-- Free shipping coupons durong addOrder
+- Free shipping coupons during addOrder
 
 ## [2.9.15] - 2020-02-05
 ### Removed

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -7,9 +7,9 @@
             <argument name="quoteMethods" xsi:type="array">
                 <item name="customer" xsi:type="string">customer</item><!-- before items for address saving -->
                 <item name="items" xsi:type="string">items</item>
+                <item name="external_coupons" xsi:type="string">external_coupons</item
                 <item name="shipping" xsi:type="string">shipping</item>
-                <item name="payment" xsi:type="string">payment</item>
-                <item name="external_coupons" xsi:type="string">external_coupons</item>
+                <item name="payment" xsi:type="string">payment</item>>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
# Pull Request Template

## Description

Coupons need to be applied before shipping is calculated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
