### PR TITLE
SG-211: dropped support for old versions

### DIFF
--- a/.github/workflows/check_and_deploy.yml
+++ b/.github/workflows/check_and_deploy.yml
@@ -2,7 +2,7 @@ name: Run CS fixer & deploy
 on: [push]
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Code style check
     steps:
       - name: Check out repository code
@@ -16,7 +16,7 @@ jobs:
   deploy:
     name: Deploy to GitHub
     needs: [check]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/') # only tags
     steps:
       - name: Get tag name
@@ -27,7 +27,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 8.1
       - name: Build ZIP
         run: ./release/build_release_package.sh
         env:
@@ -48,7 +48,7 @@ jobs:
   notify-release-success:
     name: Notify developers of new release
     needs: [deploy]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: |
       success() &&
       startsWith(github.ref, 'refs/tags/')
@@ -68,7 +68,7 @@ jobs:
   notify-release-fail:
     name: Notify developers of failed release
     needs: [deploy]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: |
       failure() &&
       startsWith(github.ref, 'refs/tags/')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- support for Magento 2 below version 2.4.4
+- PHP Support below Version 8.1
+
 ## [2.9.19] - 2024-05-10
 ### Added
 - compatibility with latest Shopgate M2 base module

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": "~8.1.0||~8.2.0||~8.3.0",
     "shopgate/cart-integration-magento2-base": "~2.9.33"
   },
   "require-dev": {

--- a/src/Block/Adminhtml/Order/DataHydrator.php
+++ b/src/Block/Adminhtml/Order/DataHydrator.php
@@ -96,11 +96,12 @@ class DataHydrator
      */
     private function cleanKeys(array $data): array
     {
+        $newData = [];
         foreach ($data as $key => $value) {
-            $data[$this->cleanKey($key)] = is_array($value) ? $this->cleanKeys($value) : $value;
-            unset($data[$key]);
+            $newKey = $this->cleanKey((string)$key);
+            $newData[$newKey] = is_array($value) ? $this->cleanKeys($value) : $value;
         }
-        return $data;
+        return $newData;
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description

Drop support for Magento 2 below 2.4.4 including PHP Support below 8.1.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
